### PR TITLE
Add CI for publishing package to npm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,22 @@
+name: Publish package to npm
+on:
+  push:
+    branches: [main]
+  # Once stable, only publish on releases
+  # release:
+    # types: [published]
+jobs:
+  publish:
+    runs-on: ubuntu-latest 
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          registry-url: https://registry.npmjs.org/
+          scope: '@picketapi'
+      - run: npm ci
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+

--- a/picket.ts
+++ b/picket.ts
@@ -224,3 +224,5 @@ export class Picket {
     return token;
   }
 }
+
+export default Picket;


### PR DESCRIPTION
### Description 

~@noahfradin Can you give admin access, so I can set the secret for CI?~ Added the `NPM_AUTH_TOKEN` secret

- Add CI to publish to [`npm`](https://www.npmjs.com/package/@picketapi/picket-js)
- While we are iterating, it will release on every push to `main`. In future, we it will only publish when we create release in Github
- Expose `Picket` as the default export of the package 