### PR TITLE
Add Support for Solana Token Ownership Authorization 

### DIFF
--- a/src/picket.ts
+++ b/src/picket.ts
@@ -174,6 +174,7 @@ export class Picket {
     chain,
     walletAddress,
     signature,
+    tokenIds,
     contractAddress,
     minTokenBalance,
     redirectURI,
@@ -197,6 +198,12 @@ export class Picket {
     minTokenBalance &&
       url.searchParams.set("minTokenBalance", String(minTokenBalance));
 
+    if (tokenIds) {
+      for (let id of tokenIds) {
+        url.searchParams.append("tokenIds", id);
+      }
+    }
+
     return url.toString();
   }
 
@@ -209,6 +216,7 @@ export class Picket {
       chain = Chains.ETH,
       walletAddress,
       signature,
+      tokenIds,
       contractAddress,
       minTokenBalance,
     }: LoginRequest = {},
@@ -244,6 +252,7 @@ export class Picket {
       walletAddress,
       signature,
       contractAddress,
+      tokenIds,
       minTokenBalance,
       redirectURI,
       state,
@@ -362,6 +371,7 @@ export class Picket {
       walletAddress,
       signature,
       contractAddress,
+      tokenIds,
       minTokenBalance,
     }: LoginRequest = {},
     { redirectURI = window.location.href }: LoginOptions = {
@@ -386,6 +396,7 @@ export class Picket {
       walletAddress,
       signature,
       contractAddress,
+      tokenIds,
       minTokenBalance,
       state,
       codeChallenge: code_challenge,

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export interface NonceResponse {
 
 export interface AuthRequirements {
   contractAddress?: string;
+  tokenIds?: string[];
   minTokenBalance?: number | string;
 }
 


### PR DESCRIPTION
### Description

Adds a `tokenIds` parameter to authorization requests to allow users to authorize token ownership on Solana. 
