### PR TITLE
Auto Close Modal on Success After 5 Seconds

### DIFF
--- a/src/connect/ConnectModal.tsx
+++ b/src/connect/ConnectModal.tsx
@@ -15,6 +15,7 @@ const displayAddress = (address: string) => {
 };
 
 const CONNECT_TIMEOUT_MS = 15000;
+const AUTO_CLOSE_MS = 5000;
 
 type WalletOption = {
   slug: string;
@@ -230,6 +231,9 @@ const ConnectModal = ({
           chain: selectedChain,
         },
       });
+
+      // start timer to close the modal
+      setTimeout(() => setIsOpen(false), AUTO_CLOSE_MS);
     } catch (err: unknown) {
       console.log(err);
       setSelectedWallet(undefined);


### PR DESCRIPTION
### Description

Per title. Automatically closes the modal after 5 seconds of authenticating.
