### PR TITLE
[PIC-195] Allow Specific Wallet Addresses to Login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@picketapi/picket-js",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@picketapi/picket-js",
-      "version": "0.0.63",
+      "version": "0.0.64",
       "license": "ISC",
       "dependencies": {
         "@coinbase/wallet-sdk": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@picketapi/picket-js",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "description": "Javascript client for the Picket API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/connect/ConnectModal.tsx
+++ b/src/connect/ConnectModal.tsx
@@ -132,6 +132,107 @@ const getWarningMessage = ({
   return `Still waiting for your signature. Open ${walletName} to approve the request.`;
 };
 
+const getErrorMessage = ({
+  err,
+  wallet,
+  state,
+  selectedChain,
+  requirements,
+}: {
+  err?: Error;
+  wallet: Wallet;
+  state: ConnectState;
+  selectedChain: string;
+  requirements?: AuthRequirements;
+}): string => {
+  const walletName =
+    // special case for WalletConnect
+    wallet?.name && wallet.name !== "WalletConnect"
+      ? wallet.name
+      : "your wallet";
+
+  if (state === "auth") {
+    if (
+      err &&
+      typeof err === "object" &&
+      "msg" in err &&
+      // @ts-ignore TS isn't respecting "msg" in err
+      typeof err.msg === "string"
+    ) {
+      // @ts-ignore TS isn't respecting "msg" in err
+      if (err.msg.toLowerCase().includes("invalid signature")) {
+        return "Signature expired. Please try again.";
+      }
+      // @ts-ignore TS isn't respecting "msg" in err
+      if (err.msg.toLowerCase().includes("token gating")) {
+        return `${toTitleCase(
+          selectedChain
+        )} doesn't support token gating yet. Reach out to team@picketapi.com for more info.`;
+      }
+      if (
+        // @ts-ignore TS isn't respecting "msg" in err
+        err.msg.toLowerCase().includes("any erc20, erc721, erc1155 tokens")
+      ) {
+        return `${
+          requirements?.contractAddress
+            ? displayWalletAddress(requirements.contractAddress)
+            : "The provided contract"
+        } is not an ERC20, ERC721, or ERC1155 token. If this error persists, please contact your site administrator or team@picketapi.com.`;
+      }
+      if (
+        // @ts-ignore TS isn't respecting "msg" in err
+        err.msg.toLowerCase().includes("any erc20, erc721, erc1155 tokens")
+      ) {
+        return `${
+          requirements?.contractAddress
+            ? displayWalletAddress(requirements.contractAddress)
+            : "The provided contract"
+        } is not an ERC20, ERC721, or ERC1155 token. If this error persists, please contact your site administrator or team@picketapi.com.`;
+      }
+      if (
+        // @ts-ignore TS isn't respecting "msg" in err
+        err.msg.toLowerCase().includes("allowedWallets must be an array")
+      ) {
+        return `Incorrect parameter type for "allowedWallets". If this error persists, please contact your site administrator or team@picketapi.com.`;
+      }
+      if (
+        // @ts-ignore TS isn't respecting "msg" in err
+        err.msg.toLowerCase().includes("allowed wallet addresses")
+      ) {
+        return "Your wallet address is not on the allowed list of wallet addresses.";
+      }
+    }
+
+    // TODO!!!
+    // assume token-gating error
+    // do not un-select wallet so we can customize the error screen
+    return NOT_ENOUGH_TOKENS_ERROR;
+  }
+
+  // check for user rejected error cases
+  if (
+    err &&
+    typeof err === "object" &&
+    "message" in err &&
+    // @ts-ignore
+    err.message.toLowerCase().includes("user rejected")
+  ) {
+    if (state === "signature") {
+      return `The signature request was rejected.`;
+    }
+
+    return `The request to connect to ${walletName} was rejected. Is your wallet unlocked?`;
+  }
+
+  // unknown error in signature state
+  if (state === "signature") {
+    return `Failed to get your signature.`;
+  }
+
+  // last resort
+  return `Failed to connect to ${walletName}.`;
+};
+
 const ConnectModal = ({
   chain,
   doAuth = false,
@@ -424,81 +525,20 @@ const ConnectModal = ({
 
       const shouldClearSelectedWallet = !wallet.qrCode;
 
-      if (state === "auth") {
-        if (
-          err &&
-          typeof err === "object" &&
-          "msg" in err &&
-          // @ts-ignore TS isn't respecting "msg" in err
-          typeof err.msg === "string"
-        ) {
-          // @ts-ignore TS isn't respecting "msg" in err
-          if (err.msg.toLowerCase().includes("invalid signature")) {
-            setError("Signature expired. Please try again.");
-            shouldClearSelectedWallet && setSelectedWallet(undefined);
-            return;
-          }
-          // @ts-ignore TS isn't respecting "msg" in err
-          if (err.msg.toLowerCase().includes("not support authorization")) {
-            setError(
-              `${toTitleCase(
-                selectedChain
-              )} doesn't support token gating yet. Reach out to team@picketapi.com for more info.`
-            );
-            shouldClearSelectedWallet && setSelectedWallet(undefined);
-            return;
-          }
-          if (
-            // @ts-ignore TS isn't respecting "msg" in err
-            err.msg.toLowerCase().includes("any erc20, erc721, erc1155 tokens")
-          ) {
-            setError(
-              `${
-                requirements?.contractAddress
-                  ? displayWalletAddress(requirements.contractAddress)
-                  : "The provided contract"
-              } is not an ERC20, ERC721, or ERC1155 token. If this error persists, please contact your site administrator or team@picketapi.com.`
-            );
-            shouldClearSelectedWallet && setSelectedWallet(undefined);
-            return;
-          }
-        }
+      const errorMsg = getErrorMessage({
+        err: err as Error | undefined,
+        state,
+        wallet,
+        selectedChain,
+        requirements,
+      });
 
-        // assume token-gating error
-        // do not un-select wallet so we can customize the error screen
-        setError(NOT_ENOUGH_TOKENS_ERROR);
-        return;
-      }
-      // clear selected wallet in all errors below
-      shouldClearSelectedWallet && setSelectedWallet(undefined);
-
-      // check for user rejected error cases
-      if (
-        err &&
-        typeof err === "object" &&
-        "message" in err &&
-        // @ts-ignore
-        err.message.toLowerCase().includes("user rejected")
-      ) {
-        if (state === "signature") {
-          setError(`The signature request was rejected.`);
-          return;
-        }
-
-        setError(
-          `The request to connect to ${wallet.name} was rejected. Is your wallet unlocked?`
-        );
-        return;
+      // do not un-select wallet on token gating error so we can customize the error screen
+      if (shouldClearSelectedWallet && errorMsg !== NOT_ENOUGH_TOKENS_ERROR) {
+        setSelectedWallet(undefined);
       }
 
-      // unknown error in signature state
-      if (state === "signature") {
-        setError(`Failed to get your signature.`);
-        return;
-      }
-
-      // last resort
-      setError(`Failed to connect to ${wallet.name}.`);
+      setError(errorMsg);
     } finally {
       // reset connect state
       setConnectState(null);

--- a/src/connect/ConnectModal.tsx
+++ b/src/connect/ConnectModal.tsx
@@ -203,9 +203,7 @@ const getErrorMessage = ({
       }
     }
 
-    // TODO!!!
     // assume token-gating error
-    // do not un-select wallet so we can customize the error screen
     return NOT_ENOUGH_TOKENS_ERROR;
   }
 

--- a/src/connect/QRCodeConnectScreen.tsx
+++ b/src/connect/QRCodeConnectScreen.tsx
@@ -36,10 +36,6 @@ const getConnectMessage = (state: ConnectState, error?: string) => {
   return "Open your phone camera or wallet to scan this QR code.";
 };
 
-// TODO:
-// 1. Handle iOS vs Android
-// 2. Handle multi-chain login
-
 const getWarningMessage = ({
   wallet,
   state,
@@ -47,7 +43,7 @@ const getWarningMessage = ({
   wallet?: Wallet;
   state: ConnectState;
 }): string => {
-  let walletName =
+  const walletName =
     // special case for WalletConnect
     wallet?.name && wallet.name !== "WalletConnect"
       ? wallet.name

--- a/src/picket.ts
+++ b/src/picket.ts
@@ -289,6 +289,7 @@ export class Picket {
     tokenIds,
     contractAddress,
     minTokenBalance,
+    allowedWallets,
     redirectURI,
     codeChallenge,
     state,
@@ -316,6 +317,12 @@ export class Picket {
       }
     }
 
+    if (allowedWallets) {
+      for (let address of allowedWallets) {
+        url.searchParams.append("allowedWallets", address);
+      }
+    }
+
     return url.toString();
   }
 
@@ -331,6 +338,7 @@ export class Picket {
       tokenIds,
       contractAddress,
       minTokenBalance,
+      allowedWallets,
     }: LoginRequest = {},
     { redirectURI = window.location.href, appState = {} }: LoginOptions = {
       redirectURI: window.location.href,
@@ -366,6 +374,7 @@ export class Picket {
       contractAddress,
       tokenIds,
       minTokenBalance,
+      allowedWallets,
       redirectURI,
       state,
       codeChallenge: code_challenge,
@@ -485,6 +494,7 @@ export class Picket {
       contractAddress,
       tokenIds,
       minTokenBalance,
+      allowedWallets,
     }: LoginRequest = {},
     { redirectURI = window.location.href }: LoginOptions = {
       redirectURI: window.location.href,
@@ -510,6 +520,7 @@ export class Picket {
       contractAddress,
       tokenIds,
       minTokenBalance,
+      allowedWallets,
       state,
       codeChallenge: code_challenge,
       redirectURI,

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export interface AuthRequirements {
   contractAddress?: string;
   tokenIds?: string[];
   minTokenBalance?: number | string;
+  allowedWallets?: string[];
 }
 
 export interface AuthenticatedUser {


### PR DESCRIPTION
### Description
Allows users to specify a list of wallet addresses that are allowed to login. This is logically OR-ed with any other requirements (token-gating), which makes for easier testing for developers to create token-gated experience.

### Commits
- Add allowedWallets to auth requirements
- Add allowedWallets to oauth2 login flows
- Remove completed todos
- Add new error messages and refactor error msg logic
