### PR TITLE
[PIC-160] Localization Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@picketapi/picket-js",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@picketapi/picket-js",
-      "version": "0.0.69",
+      "version": "0.0.70",
       "license": "ISC",
       "dependencies": {
         "@coinbase/wallet-sdk": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@picketapi/picket-js",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "description": "Javascript client for the Picket API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/connect/ConnectModal.tsx
+++ b/src/connect/ConnectModal.tsx
@@ -463,6 +463,7 @@ const ConnectModal = ({
         issuedAt,
         chainId,
         chainType,
+        locale: navigator?.language,
       };
 
       // TODO: Conditional based off Picket availability (refactor to separate library)
@@ -474,6 +475,7 @@ const ConnectModal = ({
       } = await window.picket.nonce({
         walletAddress,
         chain: selectedChain,
+        locale: context.locale,
       });
 
       const message = window.Picket.createSigningMessage({

--- a/src/picket.ts
+++ b/src/picket.ts
@@ -34,6 +34,8 @@ export interface PicketOptions {
   baseURL?: string;
 }
 
+const DEFAULT_LOCALE = "en";
+
 export const API_VERSION = "v1";
 const BASE_API_URL = `https://picketapi.com/api/${API_VERSION}`;
 
@@ -78,6 +80,8 @@ export class Picket {
   async nonce({
     walletAddress,
     chain = ChainTypes.ETH,
+    // default to English
+    locale = DEFAULT_LOCALE,
   }: NonceRequest): Promise<NonceResponse> {
     const url = `${this.baseURL}/auth/nonce`;
     const res = await fetch(url, {
@@ -86,6 +90,7 @@ export class Picket {
       body: JSON.stringify({
         chain,
         walletAddress,
+        locale,
       }),
     });
     const data = await res.json();
@@ -294,6 +299,7 @@ export class Picket {
     codeChallenge,
     state,
     responseMode,
+    locale = DEFAULT_LOCALE,
   }: AuthorizationURLRequest): string {
     const url = new URL(`${this.baseURL}/oauth2/authorize`);
     url.searchParams.set("client_id", this.#apiKey);
@@ -303,6 +309,8 @@ export class Picket {
 
     url.searchParams.set("code_challenge_method", "S256");
     url.searchParams.set("response_mode", responseMode);
+
+    url.searchParams.set("locale", locale);
 
     chain && url.searchParams.set("chain", chain);
     walletAddress && url.searchParams.set("walletAddress", walletAddress);

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export type ChainInfo = {
 export interface NonceRequest {
   chain: string;
   walletAddress: string;
+  locale?: string;
 }
 
 export interface NonceResponse {
@@ -77,19 +78,17 @@ export interface SigningMessageContext {
   chainId: number;
   issuedAt: string;
   chainType: ChainType;
+  // add locale to the context even though it is not part of the SIWE spec
+  locale?: string;
 }
 
 export interface SigningMessageRequestSimple extends NonceResponse {
   walletAddress: string;
 }
 
-export interface SigningMessageRequestSIWE extends SigningMessageRequestSimple {
-  domain: string;
-  uri: string;
-  chainId: number;
-  issuedAt: string;
-  chainType: ChainType;
-}
+export interface SigningMessageRequestSIWE
+  extends SigningMessageRequestSimple,
+    SigningMessageContext {}
 
 export type SigningMessageRequest =
   | SigningMessageRequestSimple
@@ -146,6 +145,7 @@ export interface AuthorizationURLRequest extends AuthRequirements {
   walletAddress?: string;
   signature?: string;
   responseMode: AuthorizationResponseMode;
+  locale?: string;
 }
 
 export interface AuthorizationServerWebResponse {


### PR DESCRIPTION
### Description
Passes the browsers locale to the API, so signing message statements can be localized in the user' language.

### Commits
- Add locale to types
- Add locale to nonce and authorizationURL requests
