### PR TITLE
Support Solana (Metaplex) Collections and Creator Address as Auth Requirement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@picketapi/picket-js",
-  "version": "0.0.71",
+  "version": "0.0.72",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@picketapi/picket-js",
-      "version": "0.0.71",
+      "version": "0.0.72",
       "license": "ISC",
       "dependencies": {
         "@coinbase/wallet-sdk": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@picketapi/picket-js",
-  "version": "0.0.71",
+  "version": "0.0.72",
   "description": "Javascript client for the Picket API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/picket.ts
+++ b/src/picket.ts
@@ -291,8 +291,10 @@ export class Picket {
     chain,
     walletAddress,
     signature,
-    tokenIds,
     contractAddress,
+    tokenIds,
+    collection,
+    creatorAddress,
     minTokenBalance,
     allowedWallets,
     redirectURI,
@@ -319,11 +321,17 @@ export class Picket {
     minTokenBalance &&
       url.searchParams.set("minTokenBalance", String(minTokenBalance));
 
+    // START: Solana-specific
+    collection &&
+      creatorAddress &&
+      url.searchParams.set("creatorAddress", creatorAddress);
+
     if (tokenIds) {
       for (let id of tokenIds) {
         url.searchParams.append("tokenIds", id);
       }
     }
+    // END: Solana-specific
 
     if (allowedWallets) {
       for (let address of allowedWallets) {

--- a/src/picket.ts
+++ b/src/picket.ts
@@ -322,9 +322,8 @@ export class Picket {
       url.searchParams.set("minTokenBalance", String(minTokenBalance));
 
     // START: Solana-specific
-    collection &&
-      creatorAddress &&
-      url.searchParams.set("creatorAddress", creatorAddress);
+    collection && url.searchParams.set("collection", collection);
+    creatorAddress && url.searchParams.set("creatorAddress", creatorAddress);
 
     if (tokenIds) {
       for (let id of tokenIds) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,9 +35,12 @@ export interface NonceResponse {
 
 export interface AuthRequirements {
   contractAddress?: string;
-  tokenIds?: string[];
   minTokenBalance?: number | string;
   allowedWallets?: string[];
+  // Solana specific auth requirement options
+  tokenIds?: string[];
+  collection?: string;
+  creatorAddress?: string;
 }
 
 export interface AuthenticatedUser {


### PR DESCRIPTION
### Description
This allows users to token-gate on Solana via the [Metaplex Collection Standard](https://docs.metaplex.com/programs/token-metadata/certified-collections). For older tokens that do not support the standard, users can use `creatorAddress` as a proxy. This must be used with caution as some addresses are associated with many NFT collections.


Note: No logic change required. Only add type support. All logic is handled by the Picket server.

### Commits
- Add type support for Solana collections and creator address
- Bump version
