### PR TITLE
Throw Errors on Missing Params for Creating Signing Message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@picketapi/picket-js",
-  "version": "0.0.99",
+  "version": "0.0.100",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@picketapi/picket-js",
-      "version": "0.0.99",
+      "version": "0.0.100",
       "license": "ISC",
       "dependencies": {
         "@coinbase/wallet-sdk": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@picketapi/picket-js",
-  "version": "0.0.99",
+  "version": "0.0.100",
   "description": "Javascript client for the Picket API",
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/src/connect/ConnectModal.tsx
+++ b/src/connect/ConnectModal.tsx
@@ -189,7 +189,7 @@ const getErrorMessage = ({
     if (
       err.msg.toLowerCase().includes("required to create a signing message")
     ) {
-      return "Missing required parameters to creaet a signing message";
+      return "Missing required parameters to create a signing message";
     }
     // @ts-ignore TS isn't respecting "msg" in err
     if (err.msg.toLowerCase().includes("invalid signature")) {

--- a/src/connect/ConnectModal.tsx
+++ b/src/connect/ConnectModal.tsx
@@ -179,6 +179,18 @@ const getErrorMessage = ({
     if (err.msg.toLowerCase().includes("invalid project key")) {
       return "Invalid API key. Copy your project's publishable key from your Picket dashboard: https://picketapi.com/dashboard";
     }
+    if (
+      err.msg
+        .toLowerCase()
+        .includes("required to create a SIWE signing message")
+    ) {
+      return "Missing required context parameters for SIWE";
+    }
+    if (
+      err.msg.toLowerCase().includes("required to create a signing message")
+    ) {
+      return "Missing required parameters to creaet a signing message";
+    }
     // @ts-ignore TS isn't respecting "msg" in err
     if (err.msg.toLowerCase().includes("invalid signature")) {
       return "Signature expired. Please try again.";

--- a/src/picket.ts
+++ b/src/picket.ts
@@ -703,16 +703,20 @@ export class Picket {
 
     // validate parameters
     if (!statement) {
-      throw new Error("'statement' is required to create a signing message");
+      throw new Error(
+        "'statement' is required to create a SIWE signing message"
+      );
     }
     if (!domain) {
-      throw new Error("'domain' is required to create a signing message");
+      throw new Error("'domain' is required to create a SIWE signing message");
     }
     if (!uri) {
-      throw new Error("'uri' is required to create a signing message");
+      throw new Error("'uri' is required to create a SIWE signing message");
     }
     if (!issuedAt) {
-      throw new Error("'issuedAt' is required to create a signing message");
+      throw new Error(
+        "'issuedAt' is required to create a SIWE signing message"
+      );
     }
     if (!chainId) {
       throw new Error("'chainId' is required to create a signing message");

--- a/src/picket.ts
+++ b/src/picket.ts
@@ -719,7 +719,7 @@ export class Picket {
       );
     }
     if (!chainId) {
-      throw new Error("'chainId' is required to create a signing message");
+      throw new Error("'chainId' is required to create a SIWE signing message");
     }
 
     const message = new SiweMessage({

--- a/src/picket.ts
+++ b/src/picket.ts
@@ -673,6 +673,17 @@ export class Picket {
 
   static createSigningMessage(args: SigningMessageRequest) {
     const { format = SigningMessageFormat.SIMPLE } = args;
+
+    if (!args.nonce) {
+      throw new Error("'nonce' is required to create a signing message");
+    }
+
+    if (!args.walletAddress) {
+      throw new Error(
+        "'walletAddress' is required to create a signing message"
+      );
+    }
+
     if (format === SigningMessageFormat.SIMPLE) {
       const { statement, walletAddress, nonce } =
         args as SigningMessageRequestSimple;
@@ -689,6 +700,23 @@ export class Picket {
       chainId,
       chainType,
     } = args as SigningMessageRequestSIWE;
+
+    // validate parameters
+    if (!statement) {
+      throw new Error("'statement' is required to create a signing message");
+    }
+    if (!domain) {
+      throw new Error("'domain' is required to create a signing message");
+    }
+    if (!uri) {
+      throw new Error("'uri' is required to create a signing message");
+    }
+    if (!issuedAt) {
+      throw new Error("'issuedAt' is required to create a signing message");
+    }
+    if (!chainId) {
+      throw new Error("'chainId' is required to create a signing message");
+    }
 
     const message = new SiweMessage({
       address: walletAddress,


### PR DESCRIPTION
### Description

Goal is to help developers debug the notorious "invalid signature" message.
